### PR TITLE
Added main files to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,10 @@
     "Muhammad Safraz <mr.safraz@gmail.com>"
   ],
   "description": "HTML5 File bindings for knockout js with drag and drop and custom input buttons",
+  "main": [
+    "knockout-file-bindings.js",
+    "knockout-file-bindings.css"
+  ],
   "keywords": [
     "knockoutjs",
     "html5",


### PR DESCRIPTION
Adding main files allows the binding to be used with, for instance, rails-assets and webpack without having to specify the file to be imported