### PR TITLE
multiple file bindings use wrong defaults

### DIFF
--- a/knockout-file-bindings.js
+++ b/knockout-file-bindings.js
@@ -210,7 +210,7 @@
             var sysOpts = fileBindings.customFileInputSystemOptions;
             var defOpts = fileBindings.defaultOptions;
 
-            options = $.extend(defOpts, options);
+            options = $.extend({}, defOpts, options);
 
             var allBindings = allBindingsAccessor();
             if (!allBindings.fileInput) {


### PR DESCRIPTION
When using more than one file binding, the defaults become the last used options.