### PR TITLE
Add disposal callback on file input element

### DIFF
--- a/knockout-file-bindings.js
+++ b/knockout-file-bindings.js
@@ -89,6 +89,12 @@
                 }
             };
             element.onchange();
+            
+
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                var fileData = ko.utils.unwrapObservable(valueAccessor()) || {};
+                fileData.clear = undefined;
+            });
         },
         update: function(element, valueAccessor, allBindingsAccessor) {
 

--- a/knockout-file-bindings.js
+++ b/knockout-file-bindings.js
@@ -90,7 +90,6 @@
             };
             element.onchange();
             
-
             ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
                 var fileData = ko.utils.unwrapObservable(valueAccessor()) || {};
                 fileData.clear = undefined;


### PR DESCRIPTION
This will allow the plugin to set `undefined` for `clear function`.
Those who are using this plugin in SPA will benefit to these behaviour.