### PR TITLE
Fixing base64String Array leaving old values on it

### DIFF
--- a/knockout-file-bindings.js
+++ b/knockout-file-bindings.js
@@ -162,6 +162,7 @@
                     }
                     if(index == 0 && fileData[property + 'Array'] && ko.isObservable(fileData[property + 'Array'])){
                         fileData[property + 'Array']([]);
+                        fileData['base64StringArray']([]);
                     }
 
                     var reader = new FileReader();


### PR DESCRIPTION
On my tests adding the line fix issue that casues base64StringArray do not get reset. Not sure is works on main branch and other scenarios but wanted you to check it. Probably i am missing generic use cases.