### PR TITLE
Issue 28: updating drag/drop feature to reject invalid file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ viewModel.fileData().dataURL.subscribe(function(dataURL){
 });
 ```
 
-along with `dataURL`, you can have any of `bindaryString`, `text`,  `arrayBuffer` or `base64String` based on your needs. See [Anvanced Usage](#advanced-usage) section below
+along with `dataURL`, you can have any of `bindaryString`, `text`,  `arrayBuffer` or `base64String` based on your needs. See [Advanced Usage](#advanced-usage) section below
 
 
 **View**
@@ -88,7 +88,18 @@ viewModel.fileData = ko.observable({
   
   // a special observable (optional)
   base64String: ko.observable(), // just the base64 string, without mime type or anything else
-  
+
+  // a "file types" observable to denote acceptable file types (optional)
+  // accepts any string value that is valid for the `accept` attribute of a file input
+  // if provided, will override the `accept` attribute on the target file input
+  // if not provided, the value of the `accept` attribute will be used
+  fileTypes: ko.observable(),
+
+  onInvalidFileDrop: function(fileData) {
+    // do something with rejected file
+  },
+
+
   // you can have observable arrays for each of the properties above, useful in multiple file upload selection (see Multiple file Uploads section below)
   // in the format of xxxArray: ko.observableArray(),
   /* e.g: */ fileArray: ko.observableArray(), base64StringArray: ko.observableArray(),
@@ -105,7 +116,8 @@ viewModel.fileData().base64String.subscribe(function(base64String){
 ```
 
 Recommended:
-[Reading HTML5 files](http://www.html5rocks.com/en/tutorials/file/dndfiles/#toc-reading-files)
+[Reading HTML5 files](http://www.html5rocks.com/en/tutorials/file/dndfiles/#toc-reading-files),
+[More on accept attribute](https://www.w3schools.com/tags/att_input_accept.asp)
 
 **View**
 ```html

--- a/demo.html
+++ b/demo.html
@@ -29,6 +29,7 @@
 	              buttonClass: 'btn btn-success',
 	              fileNameClass: 'disabled form-control',
 	              onClear: onClear,
+								onInvalidFileDrop: onInvalidFileDrop
 	            }" accept="image/*">
 	        </div>
 	    </div>
@@ -60,7 +61,11 @@
 <script src='http://cdnjs.cloudflare.com/ajax/libs/knockout/3.1.0/knockout-min.js'></script><script src='knockout-file-bindings.js'></script>
 <script>
     var viewModel = {};
-    viewModel.fileData = ko.observable({ dataURL: ko.observable() });
+    viewModel.fileData = ko.observable({
+			dataURL: ko.observable(),
+			// can add "fileTypes" observable here, and it will override the "accept" attribute on the file input
+			// fileTypes: ko.observable('.xlsx,image/png,audio/*')
+		});
     viewModel.multiFileData = ko.observable({ dataURLArray: ko.observableArray() });
     viewModel.onClear = function (fileData) {
         if (confirm('Are you sure?')) {
@@ -72,6 +77,10 @@
         console.log(ko.toJSON(viewModel));
         debugger;
     };
+		viewModel.onInvalidFileDrop = function(fileData) {
+			alert(fileData.name + ': Invalid file type')
+			console.error(fileData);
+		};
     ko.applyBindings(viewModel);
 </script>
 


### PR DESCRIPTION
Added behaviors to the "fileDrag" binding to either get the value from the file input's "accept" attribute, or use the new "fileTypes" property on the fileData model.

Also added an event hook so that actions can be taken upon the drop of a bad file (logging, user notification, etc.). Resolves #28.