### PR TITLE
handling multiple invalid dropped files with single event

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -83,8 +83,9 @@
 			for (var i = 0; i < failedFiles.length; i++) {
 				fileNames.push(failedFiles[i].name);
 			}
-			alert('Invalid file type: ' + fileNames.join(', '))
-			console.error(fileData);
+			var message = 'Invalid file type: ' + fileNames.join(', ');
+			alert(message)
+			console.error(message);
 		};
     ko.applyBindings(viewModel);
 </script>

--- a/demo.html
+++ b/demo.html
@@ -51,6 +51,7 @@
 	              buttonClass: 'btn btn-success',
 	              fileNameClass: 'disabled form-control',
 	              onClear: onClear,
+								onInvalidFileDrop: onInvalidFileDrop
 	            }" accept="image/*">
 	        </div>
 	    </div>
@@ -77,8 +78,12 @@
         console.log(ko.toJSON(viewModel));
         debugger;
     };
-		viewModel.onInvalidFileDrop = function(fileData) {
-			alert(fileData.name + ': Invalid file type')
+		viewModel.onInvalidFileDrop = function(failedFiles) {
+			var fileNames = [];
+			for (var i = 0; i < failedFiles.length; i++) {
+				fileNames.push(failedFiles[i].name);
+			}
+			alert('Invalid file type: ' + fileNames.join(', '))
 			console.error(fileData);
 		};
     ko.applyBindings(viewModel);

--- a/demo.html
+++ b/demo.html
@@ -29,7 +29,7 @@
 	              buttonClass: 'btn btn-success',
 	              fileNameClass: 'disabled form-control',
 	              onClear: onClear,
-								onInvalidFileDrop: onInvalidFileDrop
+	              onInvalidFileDrop: onInvalidFileDrop
 	            }" accept="image/*">
 	        </div>
 	    </div>
@@ -39,9 +39,9 @@
 	<div class="well" data-bind="fileDrag: multiFileData">
 	    <div class="form-group row">
 	        <div class="col-md-6">
-	                  <!-- ko foreach: {data: multiFileData().dataURLArray, as: 'dataURL'} -->
-	                  <img style="height: 100px; margin: 5px;" class="img-rounded  thumb" data-bind="attr: { src: dataURL }, visible: dataURL">
-	                  <!-- /ko -->
+	            <!-- ko foreach: {data: multiFileData().dataURLArray, as: 'dataURL'} -->
+	            <img style="height: 100px; margin: 5px;" class="img-rounded  thumb" data-bind="attr: { src: dataURL }, visible: dataURL">
+	            <!-- /ko -->
 	            <div data-bind="ifnot: fileData().dataURL">
 	                <label class="drag-label">Drag files here</label>
 	            </div>
@@ -51,7 +51,7 @@
 	              buttonClass: 'btn btn-success',
 	              fileNameClass: 'disabled form-control',
 	              onClear: onClear,
-								onInvalidFileDrop: onInvalidFileDrop
+	              onInvalidFileDrop: onInvalidFileDrop
 	            }" accept="image/*">
 	        </div>
 	    </div>
@@ -63,10 +63,10 @@
 <script>
     var viewModel = {};
     viewModel.fileData = ko.observable({
-			dataURL: ko.observable(),
-			// can add "fileTypes" observable here, and it will override the "accept" attribute on the file input
-			// fileTypes: ko.observable('.xlsx,image/png,audio/*')
-		});
+        dataURL: ko.observable(),
+        // can add "fileTypes" observable here, and it will override the "accept" attribute on the file input
+        // fileTypes: ko.observable('.xlsx,image/png,audio/*')
+    });
     viewModel.multiFileData = ko.observable({ dataURLArray: ko.observableArray() });
     viewModel.onClear = function (fileData) {
         if (confirm('Are you sure?')) {
@@ -78,15 +78,15 @@
         console.log(ko.toJSON(viewModel));
         debugger;
     };
-		viewModel.onInvalidFileDrop = function(failedFiles) {
-			var fileNames = [];
-			for (var i = 0; i < failedFiles.length; i++) {
-				fileNames.push(failedFiles[i].name);
-			}
-			var message = 'Invalid file type: ' + fileNames.join(', ');
-			alert(message)
-			console.error(message);
-		};
+    viewModel.onInvalidFileDrop = function(failedFiles) {
+        var fileNames = [];
+        for (var i = 0; i < failedFiles.length; i++) {
+            fileNames.push(failedFiles[i].name);
+        }
+        var message = 'Invalid file type: ' + fileNames.join(', ');
+        alert(message)
+        console.error(message);
+    };
     ko.applyBindings(viewModel);
 </script>
 

--- a/knockout-file-bindings.js
+++ b/knockout-file-bindings.js
@@ -294,20 +294,22 @@
                     if (e.type == 'drop' && e.dataTransfer) {
                         var files = e.dataTransfer.files;
                         var fileArray = [];
+                        var failedFiles = [];
                         if (files.length) {
                             for(var i = 0; i < files.length; i++){
                               if(validateDroppedFileType(fileInput, files[i])) fileArray.push(files[i]);
-                              else {
-                                // handle bad file drop, fire off a file rejected event here
-                                var fileInputContext = ko.dataFor(fileInput);
-                                if(fileInputContext && typeof fileInputContext.onInvalidFileDrop === "function") {
-                                  fileInputContext.onInvalidFileDrop(files[i]);
-                                }
-                              }
+                              else failedFiles.push(files[i]);
                             }
                             fileData.file(fileArray.length ? fileArray[0] : {});
                         }
                         if(!fileArray.length) fileData.clear();
+                        if(failedFiles.length) {
+                          // handle bad file drop, fire off a file rejected event here
+                          var fileInputContext = ko.dataFor(fileInput);
+                          if(fileInputContext && typeof fileInputContext.onInvalidFileDrop === "function") {
+                            fileInputContext.onInvalidFileDrop(failedFiles);
+                          }
+                        }
                         fileData.fileArray(fileArray);
                     }
                 };


### PR DESCRIPTION
Suggestion coming out of pull request #32 for issue #28. Instead of firing multiple `onInvalidFileDrop` events when multiple invalid files are dropped, we fire one event with an array of all invalid files.