### PR TITLE
Fix DataURLs in polluted environments.

### DIFF
--- a/knockout-file-bindings.js
+++ b/knockout-file-bindings.js
@@ -206,7 +206,7 @@
                 var checkDoneFiles = function(doneIndex, doneFileArrayResult){
                     var done = true;
                     doneFileArrayResultMap[doneIndex] = doneFileArrayResult;
-                    for(var index in fileArray){
+                    for(var index=0;index<fileArray.length;index++){
                         done = done && doneFileArrayResultMap[index];
                     }
                     if(done){
@@ -216,7 +216,7 @@
                               resultGroupedArray[key] = [];
                             }
                         }
-                        for(var index in fileArray){
+                        for(var index=0;index<fileArray.length;index++){
                             var doneFileArrayResult = doneFileArrayResultMap[index];
                             for(var prop in resultGroupedArray){
                               resultGroupedArray[prop].push(doneFileArrayResult[prop]);


### PR DESCRIPTION
Iterating with *in* is not safe on objects that could be polluted like Array because it will pick up the polluted properties as well. This fix allows this plugin to be used within Salesforce B2B Commerce and provides no meaningful change for those not in environments where Array isn't polluted.